### PR TITLE
Install callId for request trace guids

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ kotlinLoggingJvm = { module = "io.github.oshai:kotlin-logging-jvm", version.ref 
 kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinxCoroutinesSlf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "kotlinxCoroutines" }
 ktorHttpJvm = { module = "io.ktor:ktor-http-jvm", version.ref = "ktor" }
+ktorCallId = { module = "io.ktor:ktor-server-call-id", version.ref = "ktor" }
 ktorClientCio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktorClientContentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/kairo-rest-feature/src/main/kotlin/kairo/rest/server/KtorServerProvider.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/rest/server/KtorServerProvider.kt
@@ -33,6 +33,7 @@ internal class KtorServerProvider @Inject constructor(
       configure = configureEmbeddedServer(config),
       module = {
         useCallStartTime()
+        installCallId()
         installContentNegotiation()
         installStatusPages(exceptionManager)
         with(module) {

--- a/kairo-rest-feature/src/main/kotlin/kairo/rest/server/installCallId.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/rest/server/installCallId.kt
@@ -1,0 +1,18 @@
+package kairo.rest.server
+
+import io.ktor.http.*
+import io.ktor.serialization.jackson.JacksonConverter
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.callid.*
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import kairo.rest.ktorServerMapper
+import java.util.*
+import kotlin.uuid.Uuid
+
+internal fun Application.installCallId() {
+  install(CallId) {
+    retrieveFromHeader(HttpHeaders.XRequestId)
+    generate { Uuid.random().toString() }
+  }
+}


### PR DESCRIPTION
### Summary

Allow grabbing the X-Request-Id from headers or generate one for the request if it doesn't exist. 

I'm assuming we need to use a separate plugin `CallLogging` in order for the `requestTraceGuid` to show up in logs?

### Checklist

- [ ] Documentation (root README, Feature READMEs, KDoc, comments).
- [ ] Logging.
- [ ] Tests.
