### PR TITLE
Switch Gradle group to Highbeam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,8 +178,8 @@ _That said_, Kairo 6 still uses Jackson, and has not migrated to `kotlinx.serial
   A documentation website and getting started guide have also been created.
 
 - **BOMs for dependency alignment.**
-  Use `software.airborne.kairo:bom` for standalone libraries,
-  or `software.airborne.kairo:bom-full` for Kairo applications.
+  Use `com.highbeam.kairo:bom` for standalone libraries,
+  or `com.highbeam.kairo:bom-full` for Kairo applications.
   Keeps both Kairo and key external libraries in sync automatically.
 
 - **Dependency injection with [Koin](https://insert-koin.io/) (replaces Guice).**

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ plugins {
 
 repositories {
   maven {
-    url = uri("artifactregistry://us-central1-maven.pkg.dev/airborne-software/maven")
+    url = uri("artifactregistry://us-central1-maven.pkg.dev/highbeam-kairo/maven")
   }
 }
 ```
@@ -47,7 +47,7 @@ you could just add it to your `dependencies` block as you normally would.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:YOUR-LIBRARY-OF-CHOICE:6.0.0")
+  implementation("com.highbeam.kairo:YOUR-LIBRARY-OF-CHOICE:6.0.0")
 }
 ```
 
@@ -58,8 +58,8 @@ to keep your Kairo dependencies aligned.
 // build.gradle.kts
 
 dependencies {
-  implementation(platform("software.airborne.kairo:bom:6.0.0"))
-  implementation("software.airborne.kairo:YOUR-LIBRARY-OF-CHOICE")
+  implementation(platform("com.highbeam.kairo:bom:6.0.0"))
+  implementation("com.highbeam.kairo:YOUR-LIBRARY-OF-CHOICE")
 }
 ```
 
@@ -76,7 +76,7 @@ but also aligns several external library versions.
 // build.gradle.kts
 
 dependencies {
-  implementation(platform("software.airborne.kairo:bom-full:6.0.0"))
+  implementation(platform("com.highbeam.kairo:bom-full:6.0.0"))
 }
 ```
 

--- a/buildSrc/src/main/kotlin/Kairo.kt
+++ b/buildSrc/src/main/kotlin/Kairo.kt
@@ -9,12 +9,12 @@ internal val javaVersion: JavaLanguageVersion = JavaLanguageVersion.of(21)
 
 internal fun RepositoryHandler.artifactRegistry() {
   maven {
-    url = URI("artifactregistry://us-central1-maven.pkg.dev/airborne-software/maven")
+    url = URI("artifactregistry://us-central1-maven.pkg.dev/highbeam-kairo/maven")
   }
 }
 
 internal fun groupId(): String =
-  "software.airborne.kairo"
+  "com.highbeam.kairo"
 
 internal fun artifactId(path: String): String =
   path.trimStart(':').replace(':', '-')

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -20,7 +20,7 @@ plugins {
 
 repositories {
   maven {
-    url = uri("artifactregistry://us-central1-maven.pkg.dev/airborne-software/maven")
+    url = uri("artifactregistry://us-central1-maven.pkg.dev/highbeam-kairo/maven")
   }
 }
 ```
@@ -36,7 +36,7 @@ you could just add it to your `dependencies` block as you normally would.
 <Code code={`// build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:YOUR-LIBRARY-OF-CHOICE:${versionData.latest}")
+  implementation("com.highbeam.kairo:YOUR-LIBRARY-OF-CHOICE:${versionData.latest}")
 }`} lang="kotlin" />
 
 However, we recommend using Kairo's BOM
@@ -45,8 +45,8 @@ to keep your Kairo dependencies aligned.
 <Code code={`// build.gradle.kts
 
 dependencies {
-  implementation(platform("software.airborne.kairo:bom:${versionData.latest}"))
-  implementation("software.airborne.kairo:YOUR-LIBRARY-OF-CHOICE")
+  implementation(platform("com.highbeam.kairo:bom:${versionData.latest}"))
+  implementation("com.highbeam.kairo:YOUR-LIBRARY-OF-CHOICE")
 }`} lang="kotlin" />
 
 ## Building a Kairo application
@@ -61,5 +61,5 @@ but also aligns several external library versions.
 <Code code={`// build.gradle.kts
 
 dependencies {
-  implementation(platform("software.airborne.kairo:bom-full:${versionData.latest}"))
+  implementation(platform("com.highbeam.kairo:bom-full:${versionData.latest}"))
 }`} lang="kotlin" />

--- a/kairo-application/README.md
+++ b/kairo-application/README.md
@@ -14,7 +14,7 @@ Install `kairo-application`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-application")
+  implementation("com.highbeam.kairo:kairo-application")
 }
 ```
 

--- a/kairo-client/README.md
+++ b/kairo-client/README.md
@@ -13,7 +13,7 @@ they're included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-client-feature")
+  implementation("com.highbeam.kairo:kairo-client-feature")
 }
 ```
 

--- a/kairo-config/README.md
+++ b/kairo-config/README.md
@@ -38,7 +38,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-config")
+  implementation("com.highbeam.kairo:kairo-config")
 }
 ```
 

--- a/kairo-coroutines/README.md
+++ b/kairo-coroutines/README.md
@@ -16,7 +16,7 @@ they're included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-coroutines")
+  implementation("com.highbeam.kairo:kairo-coroutines")
 }
 ```
 

--- a/kairo-darb/README.md
+++ b/kairo-darb/README.md
@@ -54,7 +54,7 @@ Install `kairo-darb`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-darb")
+  implementation("com.highbeam.kairo:kairo-darb")
 }
 ```
 

--- a/kairo-datetime/README.md
+++ b/kairo-datetime/README.md
@@ -13,7 +13,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-datetime")
+  implementation("com.highbeam.kairo:kairo-datetime")
 }
 ```
 

--- a/kairo-dependency-injection/README.md
+++ b/kairo-dependency-injection/README.md
@@ -38,7 +38,7 @@ plugins {
 
 dependencies {
   ksp("io.insert-koin:koin-ksp-compiler")
-  implementation("software.airborne.kairo:kairo-dependency-injection-feature")
+  implementation("com.highbeam.kairo:kairo-dependency-injection-feature")
 }
 ```
 

--- a/kairo-exception/README.md
+++ b/kairo-exception/README.md
@@ -40,8 +40,8 @@ You can also install `kairo-exception-testing` for testing.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-exception")
-  testImplementation("software.airborne.kairo:kairo-exception-testing")
+  implementation("com.highbeam.kairo:kairo-exception")
+  testImplementation("com.highbeam.kairo:kairo-exception-testing")
 }
 ```
 

--- a/kairo-feature/README.md
+++ b/kairo-feature/README.md
@@ -32,7 +32,7 @@ you don't need `kairo-feature` too.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-feature")
+  implementation("com.highbeam.kairo:kairo-feature")
 }
 ```
 

--- a/kairo-gcp-secret-supplier/README.md
+++ b/kairo-gcp-secret-supplier/README.md
@@ -18,8 +18,8 @@ You can also install `kairo-gcp-secret-supplier-testing` for testing.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-gcp-secret-supplier")
-  testImplementation("software.airborne.kairo:kairo-gcp-secret-supplier-testing")
+  implementation("com.highbeam.kairo:kairo-gcp-secret-supplier")
+  testImplementation("com.highbeam.kairo:kairo-gcp-secret-supplier-testing")
 }
 ```
 

--- a/kairo-health-check/README.md
+++ b/kairo-health-check/README.md
@@ -20,7 +20,7 @@ Install `kairo-health-check-feature`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-health-check-feature")
+  implementation("com.highbeam.kairo:kairo-health-check-feature")
 }
 ```
 

--- a/kairo-hocon/README.md
+++ b/kairo-hocon/README.md
@@ -15,7 +15,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-hocon")
+  implementation("com.highbeam.kairo:kairo-hocon")
 }
 ```
 

--- a/kairo-id/README.md
+++ b/kairo-id/README.md
@@ -51,7 +51,7 @@ Install `kairo-id`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-id")
+  implementation("com.highbeam.kairo:kairo-id")
 }
 ```
 

--- a/kairo-image/README.md
+++ b/kairo-image/README.md
@@ -14,7 +14,7 @@ Install `kairo-image`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-image")
+  implementation("com.highbeam.kairo:kairo-image")
 }
 ```
 

--- a/kairo-integration-testing/README.md
+++ b/kairo-integration-testing/README.md
@@ -49,7 +49,7 @@ You should also install the integration testing libraries for any other modules 
 // build.gradle.kts
 
 dependencies {
-  testImplementation("software.airborne.kairo:kairo-integration-testing")
+  testImplementation("com.highbeam.kairo:kairo-integration-testing")
 }
 ```
 

--- a/kairo-integration-testing/postgres/README.md
+++ b/kairo-integration-testing/postgres/README.md
@@ -15,8 +15,8 @@ Install `kairo-integration-testing-postgres`.
 // build.gradle.kts
 
 dependencies {
-  testImplementation("software.airborne.kairo:kairo-integration-testing")
-  testImplementation("software.airborne.kairo:kairo-integration-testing-postgres")
+  testImplementation("com.highbeam.kairo:kairo-integration-testing")
+  testImplementation("com.highbeam.kairo:kairo-integration-testing-postgres")
 }
 ```
 

--- a/kairo-logging/README.md
+++ b/kairo-logging/README.md
@@ -15,7 +15,7 @@ Install `kairo-logging`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-logging")
+  implementation("com.highbeam.kairo:kairo-logging")
 }
 ```
 
@@ -46,7 +46,7 @@ This is great for simple projects.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-logging")
+  implementation("com.highbeam.kairo:kairo-logging")
   runtimeOnly("org.slf4j:slf4j-simple")
 }
 ```
@@ -60,7 +60,7 @@ Or you could use Logback.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-logging")
+  implementation("com.highbeam.kairo:kairo-logging")
   runtimeOnly("org.apache.logging.log4j:log4j-core")
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl")
 }

--- a/kairo-mailersend/README.md
+++ b/kairo-mailersend/README.md
@@ -13,7 +13,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-mailersend-feature")
+  implementation("com.highbeam.kairo:kairo-mailersend-feature")
 }
 ```
 

--- a/kairo-money/README.md
+++ b/kairo-money/README.md
@@ -17,7 +17,7 @@ they're included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-money")
+  implementation("com.highbeam.kairo:kairo-money")
 }
 ```
 

--- a/kairo-optional/README.md
+++ b/kairo-optional/README.md
@@ -33,7 +33,7 @@ Install `kairo-optional`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-optional")
+  implementation("com.highbeam.kairo:kairo-optional")
 }
 ```
 

--- a/kairo-protected-string/README.md
+++ b/kairo-protected-string/README.md
@@ -34,7 +34,7 @@ Install `kairo-protected-string`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-protected-string")
+  implementation("com.highbeam.kairo:kairo-protected-string")
 }
 ```
 

--- a/kairo-reflect/README.md
+++ b/kairo-reflect/README.md
@@ -31,7 +31,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-reflect")
+  implementation("com.highbeam.kairo:kairo-reflect")
 }
 ```
 

--- a/kairo-rest/README.md
+++ b/kairo-rest/README.md
@@ -16,7 +16,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-rest-feature")
+  implementation("com.highbeam.kairo:kairo-rest-feature")
 }
 ```
 

--- a/kairo-serialization/README.md
+++ b/kairo-serialization/README.md
@@ -51,7 +51,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-serialization")
+  implementation("com.highbeam.kairo:kairo-serialization")
 }
 ```
 

--- a/kairo-server/README.md
+++ b/kairo-server/README.md
@@ -13,7 +13,7 @@ you don't need `kairo-server` too.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-server")
+  implementation("com.highbeam.kairo:kairo-server")
 }
 ```
 

--- a/kairo-slack/README.md
+++ b/kairo-slack/README.md
@@ -16,7 +16,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-slack-feature")
+  implementation("com.highbeam.kairo:kairo-slack-feature")
 }
 ```
 

--- a/kairo-sql/README.md
+++ b/kairo-sql/README.md
@@ -24,7 +24,7 @@ However, you must include a Postgres driver at runtime.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-sql-feature")
+  implementation("com.highbeam.kairo:kairo-sql-feature")
   runtimeOnly("org.postgresql:r2dbc-postgresql")
 }
 ```
@@ -230,8 +230,8 @@ To support Postgres, install `kairo-sql-postgres` and use `PostgreSQLDialect()`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-sql-feature")
-  implementation("software.airborne.kairo:kairo-sql-postgres")
+  implementation("com.highbeam.kairo:kairo-sql-feature")
+  implementation("com.highbeam.kairo:kairo-sql-postgres")
 }
 ```
 

--- a/kairo-stytch/README.md
+++ b/kairo-stytch/README.md
@@ -13,7 +13,7 @@ it's included by default.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-stytch-feature")
+  implementation("com.highbeam.kairo:kairo-stytch-feature")
 }
 ```
 

--- a/kairo-testing/README.md
+++ b/kairo-testing/README.md
@@ -31,7 +31,7 @@ Install `kairo-testing`.
 // build.gradle.kts
 
 dependencies {
-  testImplementation("software.airborne.kairo:kairo-testing")
+  testImplementation("com.highbeam.kairo:kairo-testing")
 }
 ```
 

--- a/kairo-util/README.md
+++ b/kairo-util/README.md
@@ -13,7 +13,7 @@ Install `kairo-util`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-util")
+  implementation("com.highbeam.kairo:kairo-util")
 }
 ```
 

--- a/kairo-validation/README.md
+++ b/kairo-validation/README.md
@@ -10,7 +10,7 @@ Install `kairo-validation`.
 // build.gradle.kts
 
 dependencies {
-  implementation("software.airborne.kairo:kairo-validation")
+  implementation("com.highbeam.kairo:kairo-validation")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Change Gradle group from `software.airborne.kairo` to `com.highbeam.kairo`
- Update Artifact Registry URL from `airborne-software` to `highbeam-kairo`
- Update all module README dependency snippets and docs to reflect the new group

🤖 Generated with [Claude Code](https://claude.com/claude-code)