### PR TITLE
Update GitHub repository references to highbeamco/kairo

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/hudson155/kairo",
+          href: "https://github.com/highbeamco/kairo",
         },
       ],
       sidebar: [

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
       link: /getting-started/
       icon: right-arrow
     - text: View on GitHub
-      link: https://github.com/hudson155/kairo
+      link: https://github.com/highbeamco/kairo
       icon: external
       variant: minimal
 ---


### PR DESCRIPTION
Update GitHub links in the docs site from `hudson155/kairo` to `highbeamco/kairo` (astro config social link and homepage hero button).