### PR TITLE
Add publish workflow for timestamped versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,39 @@
+name: "Publish"
+
+permissions:
+  contents: "read"
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+concurrency:
+  group: "publish-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  main:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Check out"
+        uses: "actions/checkout@v6" # https://github.com/actions/checkout/releases
+      - name: "GCP auth"
+        uses: "google-github-actions/auth@v3" # https://github.com/google-github-actions/auth/releases
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+      - name: "Set up Java"
+        uses: "actions/setup-java@v5" # https://github.com/actions/setup-java/releases
+        with:
+          java-version: "21"
+          distribution: "corretto"
+          cache: "gradle"
+      - name: "Compute version"
+        id: "version"
+        run: |
+          VERSION="$(date -u '+%Y%m%d.%H%M%S')-$(git rev-parse --short HEAD)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: "Gradle publish"
+        run: |
+          ./gradlew publish -Pversion=${{ steps.version.outputs.version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 name: "Publish"
 
 permissions:
-  contents: "read"
+  contents: "write"
 
 on:
   push:
@@ -29,7 +29,14 @@ jobs:
           java-version: "21"
           distribution: "corretto"
           cache: "gradle"
+      - name: "Compute version"
+        id: "version"
+        run: |
+          echo "version=$(date -u '+%Y%m%d.%H%M%S')-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: "Gradle publish"
         run: |
-          VERSION="$(date -u '+%Y%m%d.%H%M%S')-$(git rev-parse --short HEAD)"
-          ./gradlew publish -Pversion="$VERSION"
+          ./gradlew publish -Pversion="${{ steps.version.outputs.version }}"
+      - name: "Tag"
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,11 +29,7 @@ jobs:
           java-version: "21"
           distribution: "corretto"
           cache: "gradle"
-      - name: "Compute version"
-        id: "version"
-        run: |
-          VERSION="$(date -u '+%Y%m%d.%H%M%S')-$(git rev-parse --short HEAD)"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: "Gradle publish"
         run: |
-          ./gradlew publish -Pversion=${{ steps.version.outputs.version }}
+          VERSION="$(date -u '+%Y%m%d.%H%M%S')-$(git rev-parse --short HEAD)"
+          ./gradlew publish -Pversion="$VERSION"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: "publish-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   main:


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that publishes all modules to Artifact Registry on every push to `main` (and manual dispatch).
- Version format is `YYYYMMDD.HHmmss-<shortsha>` (for example, `20260213.143052-abc1234`), which Gradle/Maven will always consider newer than regular semver versions like `1.0.0`.

Closes #5

## Test plan
- [ ] Merge and verify the workflow runs successfully on push to main.
- [ ] Confirm artifacts appear in Artifact Registry with the expected version format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)