### PR TITLE
Rename Kotlin CI

### DIFF
--- a/.github/workflows/kotlin-ci.yaml
+++ b/.github/workflows/kotlin-ci.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "Kotlin CI"
 
 permissions:
   contents: "read"
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "ci-${{ github.ref }}"
+  group: "kotlin-ci-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Renames the Kotlin CI workflow to match the docs/terraform naming convention.