### PR TITLE
Disable UnnecessaryFullyQualifiedName

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -830,7 +830,7 @@ style:
   UnnecessaryFilter:
     active: true
   UnnecessaryFullyQualifiedName:
-    active: true
+    active: false
   UnnecessaryInheritance:
     active: true
   UnnecessaryInnerClass:

--- a/kairo-ktor/src/main/kotlin/kairo/ktor/KairoConverter.kt
+++ b/kairo-ktor/src/main/kotlin/kairo/ktor/KairoConverter.kt
@@ -74,7 +74,6 @@ public class KairoConverter(private val json: KairoJson) : ContentConverter {
 }
 
 /** Registers [KairoConverter] for content negotiation on a Ktor HTTP client. */
-@Suppress("UnnecessaryFullyQualifiedName")
 public fun io.ktor.client.plugins.contentnegotiation.ContentNegotiationConfig.kairoConversion(
   json: KairoJson = KairoJson(),
   contentType: ContentType = ContentType.Application.Json,
@@ -83,7 +82,6 @@ public fun io.ktor.client.plugins.contentnegotiation.ContentNegotiationConfig.ka
 }
 
 /** Registers [KairoConverter] for content negotiation on a Ktor HTTP server. */
-@Suppress("UnnecessaryFullyQualifiedName")
 public fun io.ktor.server.plugins.contentnegotiation.ContentNegotiationConfig.kairoConversion(
   json: KairoJson = KairoJson(),
   contentType: ContentType = ContentType.Application.Json,

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinDayOfWeekDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinDayOfWeekDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinDayOfWeekDeserializer : StdDeserializer<DayOfWeek>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): DayOfWeek {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaDayOfWeek = ctxt.readValue(p, java.time.DayOfWeek::class.java)
     return javaDayOfWeek.toKotlinDayOfWeek()
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinDurationDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinDurationDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinDurationDeserializer : StdDeserializer<Duration>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): Duration {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaDuration = ctxt.readValue(p, java.time.Duration::class.java)
     return javaDuration.toKotlinDuration()
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinInstantDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinInstantDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinInstantDeserializer : StdDeserializer<Instant>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): Instant {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaInstant = ctxt.readValue(p, java.time.Instant::class.java)
     return javaInstant.toKotlinInstant()
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinLocalDateDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinLocalDateDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinLocalDateDeserializer : StdDeserializer<LocalDate>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): LocalDate {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaLocalDate = ctxt.readValue(p, java.time.LocalDate::class.java)
     return javaLocalDate.toKotlinLocalDate()
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinLocalDateTimeDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinLocalDateTimeDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinLocalDateTimeDeserializer : StdDeserializer<LocalDateTime>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): LocalDateTime {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaLocalDateTime = ctxt.readValue(p, java.time.LocalDateTime::class.java)
     return javaLocalDateTime.toKotlinLocalDateTime()
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinLocalTimeDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinLocalTimeDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinLocalTimeDeserializer : StdDeserializer<LocalTime>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): LocalTime {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaLocalTime = ctxt.readValue(p, java.time.LocalTime::class.java)
     return javaLocalTime.toKotlinLocalTime()
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinMonthDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinMonthDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinMonthDeserializer : StdDeserializer<Month>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): Month {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaMonth = ctxt.readValue(p, java.time.Month::class.java)
     return javaMonth.toKotlinMonth()
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinYearMonthDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/KotlinYearMonthDeserializer.kt
@@ -13,7 +13,6 @@ internal class KotlinYearMonthDeserializer : StdDeserializer<YearMonth>(
     p: JsonParser,
     ctxt: DeserializationContext,
   ): YearMonth {
-    @Suppress("UnnecessaryFullyQualifiedName")
     val javaYearMonth = ctxt.readValue(p, java.time.YearMonth::class.java)
     return javaYearMonth.toKotlinYearMonth()
   }


### PR DESCRIPTION
This rule interferes with Koin, and there's no configuration options available other than turning it off.