### PR TITLE
Add OAuth login flow for admin dashboard

### DIFF
--- a/kairo-admin/src/main/kotlin/kairo/admin/AdminDashboardConfig.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/AdminDashboardConfig.kt
@@ -7,4 +7,5 @@ public data class AdminDashboardConfig(
   val docsUrl: String? = null,
   val githubRepoUrl: String? = null,
   val kdocsUrl: String? = null,
+  val oauth: AdminOAuthConfig? = null,
 )

--- a/kairo-admin/src/main/kotlin/kairo/admin/AdminOAuthConfig.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/AdminOAuthConfig.kt
@@ -1,0 +1,25 @@
+package kairo.admin
+
+/**
+ * Configuration for OAuth 2.0 Authorization Code flow.
+ * When provided to [AdminDashboardConfig], the admin login page will redirect
+ * to the OAuth provider instead of showing a manual token input form.
+ */
+public data class AdminOAuthConfig(
+  /** Full authorize endpoint URL, e.g. "https://tenant.us.auth0.com/authorize". */
+  val authorizeUrl: String,
+  /** Full token endpoint URL, e.g. "https://tenant.us.auth0.com/oauth/token". */
+  val tokenUrl: String,
+  /** OAuth client ID for this application. */
+  val clientId: String,
+  /** OAuth client secret used to exchange the authorization code for tokens. */
+  val clientSecret: String,
+  /** OAuth scopes to request. */
+  val scopes: List<String> = listOf("openid", "profile", "email"),
+  /** API audience (required by Auth0 to return a JWT access token). */
+  val audience: String? = null,
+  /** Display name shown on the login button, e.g. "Auth0" or "Google". */
+  val providerName: String = "OAuth",
+  /** Optional logout URL to redirect to after clearing the session cookie. */
+  val logoutUrl: String? = null,
+)

--- a/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
@@ -7,14 +7,22 @@ import io.ktor.server.html.respondHtml
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respondRedirect
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.security.SecureRandom
 import java.util.Base64
 import kairo.admin.AdminDashboardConfig
+import kairo.admin.AdminOAuthConfig
 import kairo.admin.collector.ConfigCollector
 import kairo.admin.collector.DatabaseCollector
 import kairo.admin.collector.DependencyCollector
@@ -72,6 +80,8 @@ internal class AdminDashboardHandler(
     if (stytchModules != null) add("auth")
     if (emailTemplates != null) add("email")
   }
+
+  private val httpClient: HttpClient = HttpClient.newHttpClient()
 
   @Suppress("CognitiveComplexMethod", "SuspendFunSwallowedCancellation")
   override fun Application.routing() {
@@ -142,21 +152,94 @@ internal class AdminDashboardHandler(
       }
     }
 
+    // Manual token login (fallback when OAuth is not configured).
     post("/login") {
       val params = call.receiveParameters()
       val token = params["token"].orEmpty().trim()
       if (token.isNotEmpty()) {
+        setSessionCookie(token)
+      }
+      call.respondRedirect(config.pathPrefix + "/")
+    }
+
+    // OAuth: redirect to the authorization server.
+    if (config.oauth != null) {
+      get("/login/oauth") {
+        val oauth = config.oauth!!
+        val state = generateState()
         call.response.cookies.append(
           Cookie(
-            name = COOKIE_NAME,
-            value = token,
+            name = STATE_COOKIE_NAME,
+            value = state,
             path = config.pathPrefix,
             httpOnly = true,
             secure = call.request.local.scheme == "https",
+            maxAge = STATE_MAX_AGE_SECONDS,
           ),
         )
+        val redirectUri = buildCallbackUrl()
+        val params = buildMap {
+          put("response_type", "code")
+          put("client_id", oauth.clientId)
+          put("redirect_uri", redirectUri)
+          put("scope", oauth.scopes.joinToString(" "))
+          put("state", state)
+          if (oauth.audience != null) put("audience", oauth.audience)
+        }
+        val query = params.entries.joinToString("&") { (k, v) ->
+          "${URLEncoder.encode(k, Charsets.UTF_8)}=${URLEncoder.encode(v, Charsets.UTF_8)}"
+        }
+        call.respondRedirect("${oauth.authorizeUrl}?$query")
       }
-      call.respondRedirect(config.pathPrefix + "/")
+
+      // OAuth: handle the callback from the authorization server.
+      get("/callback") {
+        val oauth = config.oauth!!
+        val code = call.request.queryParameters["code"]
+        val returnedState = call.request.queryParameters["state"]
+        val error = call.request.queryParameters["error"]
+
+        if (error != null) {
+          call.respondText(
+            "OAuth error: $error - ${call.request.queryParameters["error_description"].orEmpty()}",
+            status = HttpStatusCode.BadRequest,
+          )
+          return@get
+        }
+
+        // Verify state to prevent CSRF.
+        val expectedState = call.request.cookies[STATE_COOKIE_NAME]
+        if (returnedState == null || returnedState != expectedState) {
+          call.respondText("Invalid OAuth state parameter.", status = HttpStatusCode.BadRequest)
+          return@get
+        }
+
+        // Clear the state cookie.
+        call.response.cookies.append(
+          Cookie(
+            name = STATE_COOKIE_NAME,
+            value = "",
+            path = config.pathPrefix,
+            httpOnly = true,
+            maxAge = 0,
+          ),
+        )
+
+        if (code == null) {
+          call.respondText("Missing authorization code.", status = HttpStatusCode.BadRequest)
+          return@get
+        }
+
+        val redirectUri = buildCallbackUrl()
+        val accessToken = exchangeCodeForToken(oauth, code, redirectUri)
+        if (accessToken == null) {
+          call.respondText("Failed to exchange authorization code.", status = HttpStatusCode.BadGateway)
+          return@get
+        }
+
+        setSessionCookie(accessToken)
+        call.respondRedirect("${config.pathPrefix}/")
+      }
     }
 
     post("/logout") {
@@ -169,7 +252,68 @@ internal class AdminDashboardHandler(
           maxAge = 0,
         ),
       )
-      call.respondRedirect("${config.pathPrefix}/login")
+      val logoutUrl = config.oauth?.logoutUrl
+      if (logoutUrl != null) {
+        call.respondRedirect(logoutUrl)
+      } else {
+        call.respondRedirect("${config.pathPrefix}/login")
+      }
+    }
+  }
+
+  private fun RoutingContext.setSessionCookie(token: String) {
+    call.response.cookies.append(
+      Cookie(
+        name = COOKIE_NAME,
+        value = token,
+        path = config.pathPrefix,
+        httpOnly = true,
+        secure = call.request.local.scheme == "https",
+      ),
+    )
+  }
+
+  private fun RoutingContext.buildCallbackUrl(): String {
+    val origin = call.request.origin
+    val port = origin.serverPort
+    val scheme = origin.scheme
+    val host = origin.serverHost
+    val portSuffix = when {
+      scheme == "https" && port == 443 -> ""
+      scheme == "http" && port == 80 -> ""
+      else -> ":$port"
+    }
+    return "$scheme://$host$portSuffix${config.pathPrefix}/callback"
+  }
+
+  /**
+   * Exchanges an OAuth authorization code for an access token using the token endpoint.
+   */
+  @Suppress("SwallowedException")
+  private fun exchangeCodeForToken(oauth: AdminOAuthConfig, code: String, redirectUri: String): String? {
+    val body = buildMap {
+      put("grant_type", "authorization_code")
+      put("client_id", oauth.clientId)
+      put("client_secret", oauth.clientSecret)
+      put("code", code)
+      put("redirect_uri", redirectUri)
+    }.entries.joinToString("&") { (k, v) ->
+      "${URLEncoder.encode(k, Charsets.UTF_8)}=${URLEncoder.encode(v, Charsets.UTF_8)}"
+    }
+
+    val request = HttpRequest.newBuilder()
+      .uri(URI.create(oauth.tokenUrl))
+      .header("Content-Type", "application/x-www-form-urlencoded")
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+      .build()
+
+    return try {
+      val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+      if (response.statusCode() != 200) return null
+      // Parse access_token from the JSON response without adding a JSON library dependency.
+      parseAccessToken(response.body())
+    } catch (_: Exception) {
+      null
     }
   }
 
@@ -530,5 +674,32 @@ internal class AdminDashboardHandler(
 
   private companion object {
     const val COOKIE_NAME: String = "kairo_admin_token"
+    const val STATE_COOKIE_NAME: String = "kairo_admin_oauth_state"
+    const val STATE_MAX_AGE_SECONDS: Int = 600
+
+    private val secureRandom = SecureRandom()
+
+    fun generateState(): String {
+      val bytes = ByteArray(32)
+      secureRandom.nextBytes(bytes)
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    /**
+     * Extracts the "access_token" value from a JSON response string
+     * without requiring a JSON parsing library.
+     */
+    fun parseAccessToken(json: String): String? {
+      val key = "\"access_token\""
+      val idx = json.indexOf(key)
+      if (idx < 0) return null
+      val colonIdx = json.indexOf(':', idx + key.length)
+      if (colonIdx < 0) return null
+      val startQuote = json.indexOf('"', colonIdx + 1)
+      if (startQuote < 0) return null
+      val endQuote = json.indexOf('"', startQuote + 1)
+      if (endQuote < 0) return null
+      return json.substring(startQuote + 1, endQuote)
+    }
   }
 }

--- a/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
@@ -147,25 +147,21 @@ internal class AdminDashboardHandler(
 
   private fun Route.loginRoutes() {
     get("/login") {
-      call.respondHtml {
-        loginView(config)
+      if (config.oauth != null) {
+        // If OAuth is configured, redirect directly to the provider.
+        call.respondRedirect("${config.pathPrefix}/login/oauth")
+      } else {
+        call.respondHtml {
+          loginView(config)
+        }
       }
     }
 
-    // Manual token login (fallback when OAuth is not configured).
-    post("/login") {
-      val params = call.receiveParameters()
-      val token = params["token"].orEmpty().trim()
-      if (token.isNotEmpty()) {
-        setSessionCookie(token)
-      }
-      call.respondRedirect(config.pathPrefix + "/")
-    }
-
-    // OAuth: redirect to the authorization server.
     if (config.oauth != null) {
+      val oauth = config.oauth!!
+
+      // OAuth: redirect to the authorization server.
       get("/login/oauth") {
-        val oauth = config.oauth!!
         val state = generateState()
         call.response.cookies.append(
           Cookie(
@@ -194,7 +190,6 @@ internal class AdminDashboardHandler(
 
       // OAuth: handle the callback from the authorization server.
       get("/callback") {
-        val oauth = config.oauth!!
         val code = call.request.queryParameters["code"]
         val returnedState = call.request.queryParameters["state"]
         val error = call.request.queryParameters["error"]

--- a/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
@@ -146,22 +146,11 @@ internal class AdminDashboardHandler(
   }
 
   private fun Route.loginRoutes() {
-    get("/login") {
-      if (config.oauth != null) {
-        // If OAuth is configured, redirect directly to the provider.
-        call.respondRedirect("${config.pathPrefix}/login/oauth")
-      } else {
-        call.respondHtml {
-          loginView(config)
-        }
-      }
-    }
-
     if (config.oauth != null) {
       val oauth = config.oauth!!
 
-      // OAuth: redirect to the authorization server.
-      get("/login/oauth") {
+      // GET /login initiates the OAuth Authorization Code flow directly.
+      get("/login") {
         val state = generateState()
         call.response.cookies.append(
           Cookie(
@@ -188,7 +177,7 @@ internal class AdminDashboardHandler(
         call.respondRedirect("${oauth.authorizeUrl}?$query")
       }
 
-      // OAuth: handle the callback from the authorization server.
+      // Handle the callback from the authorization server.
       get("/callback") {
         val code = call.request.queryParameters["code"]
         val returnedState = call.request.queryParameters["state"]
@@ -234,6 +223,13 @@ internal class AdminDashboardHandler(
 
         setSessionCookie(accessToken)
         call.respondRedirect("${config.pathPrefix}/")
+      }
+    } else {
+      // No OAuth configured — show a static error page.
+      get("/login") {
+        call.respondHtml {
+          loginView(config)
+        }
       }
     }
 

--- a/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/handler/AdminDashboardHandler.kt
@@ -1,5 +1,6 @@
 package kairo.admin.handler
 
+import io.ktor.http.Cookie
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.html.respondHtml
@@ -41,6 +42,7 @@ import kairo.admin.view.homeView
 import kairo.admin.view.integrationsView
 import kairo.admin.view.jvmStatsPartial
 import kairo.admin.view.jvmView
+import kairo.admin.view.loginView
 import kairo.admin.view.loggingView
 import kairo.admin.view.slackView
 import kairo.rest.HasRouting
@@ -77,6 +79,7 @@ internal class AdminDashboardHandler(
       staticResources("${config.pathPrefix}/static", "static/admin")
 
       route(config.pathPrefix) {
+        loginRoutes()
         homeRoute()
         endpointRoutes()
         configRoutes()
@@ -97,15 +100,78 @@ internal class AdminDashboardHandler(
 
   private fun Route.authGet(path: String = "", body: suspend RoutingContext.() -> Unit): Route =
     get(path) {
-      auth?.invoke(AuthReceiver.forCall(call))
+      if (auth != null) {
+        applyBearerTokenOverride()
+        try {
+          auth.invoke(AuthReceiver.forCall(call))
+        } catch (_: Exception) {
+          call.respondRedirect("${config.pathPrefix}/login")
+          return@get
+        }
+      }
       body()
     }
 
   private fun Route.authPost(path: String = "", body: suspend RoutingContext.() -> Unit): Route =
     post(path) {
-      auth?.invoke(AuthReceiver.forCall(call))
+      if (auth != null) {
+        applyBearerTokenOverride()
+        try {
+          auth.invoke(AuthReceiver.forCall(call))
+        } catch (_: Exception) {
+          call.respondRedirect("${config.pathPrefix}/login")
+          return@post
+        }
+      }
       body()
     }
+
+  /**
+   * Copies the bearer token from the admin session cookie onto the call attributes
+   * so that [AuthReceiver.verify] can find it.
+   */
+  private fun RoutingContext.applyBearerTokenOverride() {
+    val token = call.request.cookies[COOKIE_NAME] ?: return
+    call.attributes.put(AuthReceiver.BearerTokenOverride, token)
+  }
+
+  private fun Route.loginRoutes() {
+    get("/login") {
+      call.respondHtml {
+        loginView(config)
+      }
+    }
+
+    post("/login") {
+      val params = call.receiveParameters()
+      val token = params["token"].orEmpty().trim()
+      if (token.isNotEmpty()) {
+        call.response.cookies.append(
+          Cookie(
+            name = COOKIE_NAME,
+            value = token,
+            path = config.pathPrefix,
+            httpOnly = true,
+            secure = call.request.local.scheme == "https",
+          ),
+        )
+      }
+      call.respondRedirect(config.pathPrefix + "/")
+    }
+
+    post("/logout") {
+      call.response.cookies.append(
+        Cookie(
+          name = COOKIE_NAME,
+          value = "",
+          path = config.pathPrefix,
+          httpOnly = true,
+          maxAge = 0,
+        ),
+      )
+      call.respondRedirect("${config.pathPrefix}/login")
+    }
+  }
 
   @Suppress("SuspendFunSwallowedCancellation")
   private fun Route.homeRoute() {
@@ -460,5 +526,9 @@ internal class AdminDashboardHandler(
         }
       }
     }
+  }
+
+  private companion object {
+    const val COOKIE_NAME: String = "kairo_admin_token"
   }
 }

--- a/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
@@ -1,22 +1,17 @@
 package kairo.admin.view
 
 import kairo.admin.AdminDashboardConfig
-import kotlinx.html.ButtonType
-import kotlinx.html.FormMethod
 import kotlinx.html.HTML
 import kotlinx.html.a
 import kotlinx.html.body
-import kotlinx.html.button
 import kotlinx.html.classes
 import kotlinx.html.div
-import kotlinx.html.form
 import kotlinx.html.h2
 import kotlinx.html.head
 import kotlinx.html.img
 import kotlinx.html.link
 import kotlinx.html.meta
 import kotlinx.html.p
-import kotlinx.html.textArea
 import kotlinx.html.title
 
 @Suppress("LongMethod")
@@ -43,64 +38,27 @@ internal fun HTML.loginView(config: AdminDashboardConfig) {
           classes = setOf("text-xl", "font-semibold", "text-gray-900")
           +"${config.serverName ?: config.title} Admin"
         }
-        if (config.oauth != null) {
-          p {
-            classes = setOf("text-sm", "text-gray-500", "mt-1")
-            +"Sign in to continue."
-          }
-        } else {
-          p {
-            classes = setOf("text-sm", "text-gray-500", "mt-1")
-            +"Paste a valid bearer token to continue."
-          }
+        p {
+          classes = setOf("text-sm", "text-gray-500", "mt-1")
+          +"Sign in to continue."
         }
       }
       if (config.oauth != null) {
-        oauthLoginForm(config)
+        a {
+          href = "${config.pathPrefix}/login/oauth"
+          classes = setOf(
+            "w-full", "block", "text-center", "rounded-md", "bg-indigo-600", "px-4", "py-2",
+            "text-sm", "font-medium", "text-white",
+            "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
+          )
+          +"Sign in with ${config.oauth!!.providerName}"
+        }
       } else {
-        tokenLoginForm(config)
+        p {
+          classes = setOf("text-sm", "text-red-600", "text-center")
+          +"OAuth is not configured. Set AdminOAuthConfig to enable login."
+        }
       }
-    }
-  }
-}
-
-private fun kotlinx.html.DIV.oauthLoginForm(config: AdminDashboardConfig) {
-  a {
-    href = "${config.pathPrefix}/login/oauth"
-    classes = setOf(
-      "w-full", "block", "text-center", "rounded-md", "bg-indigo-600", "px-4", "py-2",
-      "text-sm", "font-medium", "text-white",
-      "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
-    )
-    +"Sign in with ${config.oauth!!.providerName}"
-  }
-}
-
-private fun kotlinx.html.DIV.tokenLoginForm(config: AdminDashboardConfig) {
-  form {
-    method = FormMethod.post
-    action = "${config.pathPrefix}/login"
-    div {
-      classes = setOf("mb-4")
-      textArea {
-        name = "token"
-        rows = "4"
-        classes = setOf(
-          "w-full", "rounded-md", "border", "border-gray-300", "px-3", "py-2",
-          "text-sm", "font-mono", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
-          "placeholder-gray-400",
-        )
-        placeholder = "eyJhbGciOiJSUzI1NiIs..."
-      }
-    }
-    button {
-      type = ButtonType.submit
-      classes = setOf(
-        "w-full", "rounded-md", "bg-indigo-600", "px-4", "py-2",
-        "text-sm", "font-medium", "text-white",
-        "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
-      )
-      +"Sign in"
     }
   }
 }

--- a/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
@@ -2,7 +2,6 @@ package kairo.admin.view
 
 import kairo.admin.AdminDashboardConfig
 import kotlinx.html.HTML
-import kotlinx.html.a
 import kotlinx.html.body
 import kotlinx.html.classes
 import kotlinx.html.div
@@ -14,7 +13,10 @@ import kotlinx.html.meta
 import kotlinx.html.p
 import kotlinx.html.title
 
-@Suppress("LongMethod")
+/**
+ * Rendered only when auth is required but OAuth is not configured.
+ * When OAuth is configured, GET /login redirects straight to the provider.
+ */
 internal fun HTML.loginView(config: AdminDashboardConfig) {
   head {
     meta(charset = "utf-8")
@@ -28,7 +30,7 @@ internal fun HTML.loginView(config: AdminDashboardConfig) {
     div {
       classes = setOf("w-full", "max-w-md", "p-8")
       div {
-        classes = setOf("flex", "flex-col", "items-center", "mb-8")
+        classes = setOf("flex", "flex-col", "items-center")
         img {
           src = "${config.pathPrefix}/static/img/logo.png"
           alt = "Logo"
@@ -39,23 +41,7 @@ internal fun HTML.loginView(config: AdminDashboardConfig) {
           +"${config.serverName ?: config.title} Admin"
         }
         p {
-          classes = setOf("text-sm", "text-gray-500", "mt-1")
-          +"Sign in to continue."
-        }
-      }
-      if (config.oauth != null) {
-        a {
-          href = "${config.pathPrefix}/login/oauth"
-          classes = setOf(
-            "w-full", "block", "text-center", "rounded-md", "bg-indigo-600", "px-4", "py-2",
-            "text-sm", "font-medium", "text-white",
-            "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
-          )
-          +"Sign in with ${config.oauth!!.providerName}"
-        }
-      } else {
-        p {
-          classes = setOf("text-sm", "text-red-600", "text-center")
+          classes = setOf("text-sm", "text-red-600", "mt-4", "text-center")
           +"OAuth is not configured. Set AdminOAuthConfig to enable login."
         }
       }

--- a/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
@@ -1,0 +1,76 @@
+package kairo.admin.view
+
+import kairo.admin.AdminDashboardConfig
+import kotlinx.html.HTML
+import kotlinx.html.body
+import kotlinx.html.button
+import kotlinx.html.classes
+import kotlinx.html.div
+import kotlinx.html.form
+import kotlinx.html.h2
+import kotlinx.html.head
+import kotlinx.html.img
+import kotlinx.html.link
+import kotlinx.html.meta
+import kotlinx.html.p
+import kotlinx.html.textArea
+import kotlinx.html.title
+
+@Suppress("LongMethod")
+internal fun HTML.loginView(config: AdminDashboardConfig) {
+  head {
+    meta(charset = "utf-8")
+    meta(name = "viewport", content = "width=device-width, initial-scale=1")
+    title { +"${config.serverName ?: config.title} - Login" }
+    link(rel = "icon", type = "image/png", href = "${config.pathPrefix}/static/img/logo.png")
+    link(rel = "stylesheet", href = "${config.pathPrefix}/static/css/tailwind.css")
+  }
+  body {
+    classes = setOf("bg-white", "min-h-screen", "flex", "items-center", "justify-center")
+    div {
+      classes = setOf("w-full", "max-w-md", "p-8")
+      div {
+        classes = setOf("flex", "flex-col", "items-center", "mb-8")
+        img {
+          src = "${config.pathPrefix}/static/img/logo.png"
+          alt = "Logo"
+          classes = setOf("w-12", "h-12", "mb-4")
+        }
+        h2 {
+          classes = setOf("text-xl", "font-semibold", "text-gray-900")
+          +"${config.serverName ?: config.title} Admin"
+        }
+        p {
+          classes = setOf("text-sm", "text-gray-500", "mt-1")
+          +"Paste a valid bearer token to continue."
+        }
+      }
+      form {
+        method = kotlinx.html.FormMethod.post
+        action = "${config.pathPrefix}/login"
+        div {
+          classes = setOf("mb-4")
+          textArea {
+            name = "token"
+            rows = "4"
+            classes = setOf(
+              "w-full", "rounded-md", "border", "border-gray-300", "px-3", "py-2",
+              "text-sm", "font-mono", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
+              "placeholder-gray-400",
+            )
+            placeholder = "eyJhbGciOiJSUzI1NiIs..."
+          }
+        }
+        button {
+          type = kotlinx.html.ButtonType.submit
+          classes = setOf(
+            "w-full", "rounded-md", "bg-indigo-600", "px-4", "py-2",
+            "text-sm", "font-medium", "text-white",
+            "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
+          )
+          +"Sign in"
+        }
+      }
+    }
+  }
+}

--- a/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
+++ b/kairo-admin/src/main/kotlin/kairo/admin/view/LoginView.kt
@@ -1,7 +1,10 @@
 package kairo.admin.view
 
 import kairo.admin.AdminDashboardConfig
+import kotlinx.html.ButtonType
+import kotlinx.html.FormMethod
 import kotlinx.html.HTML
+import kotlinx.html.a
 import kotlinx.html.body
 import kotlinx.html.button
 import kotlinx.html.classes
@@ -40,37 +43,64 @@ internal fun HTML.loginView(config: AdminDashboardConfig) {
           classes = setOf("text-xl", "font-semibold", "text-gray-900")
           +"${config.serverName ?: config.title} Admin"
         }
-        p {
-          classes = setOf("text-sm", "text-gray-500", "mt-1")
-          +"Paste a valid bearer token to continue."
-        }
-      }
-      form {
-        method = kotlinx.html.FormMethod.post
-        action = "${config.pathPrefix}/login"
-        div {
-          classes = setOf("mb-4")
-          textArea {
-            name = "token"
-            rows = "4"
-            classes = setOf(
-              "w-full", "rounded-md", "border", "border-gray-300", "px-3", "py-2",
-              "text-sm", "font-mono", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
-              "placeholder-gray-400",
-            )
-            placeholder = "eyJhbGciOiJSUzI1NiIs..."
+        if (config.oauth != null) {
+          p {
+            classes = setOf("text-sm", "text-gray-500", "mt-1")
+            +"Sign in to continue."
+          }
+        } else {
+          p {
+            classes = setOf("text-sm", "text-gray-500", "mt-1")
+            +"Paste a valid bearer token to continue."
           }
         }
-        button {
-          type = kotlinx.html.ButtonType.submit
-          classes = setOf(
-            "w-full", "rounded-md", "bg-indigo-600", "px-4", "py-2",
-            "text-sm", "font-medium", "text-white",
-            "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
-          )
-          +"Sign in"
-        }
       }
+      if (config.oauth != null) {
+        oauthLoginForm(config)
+      } else {
+        tokenLoginForm(config)
+      }
+    }
+  }
+}
+
+private fun kotlinx.html.DIV.oauthLoginForm(config: AdminDashboardConfig) {
+  a {
+    href = "${config.pathPrefix}/login/oauth"
+    classes = setOf(
+      "w-full", "block", "text-center", "rounded-md", "bg-indigo-600", "px-4", "py-2",
+      "text-sm", "font-medium", "text-white",
+      "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
+    )
+    +"Sign in with ${config.oauth!!.providerName}"
+  }
+}
+
+private fun kotlinx.html.DIV.tokenLoginForm(config: AdminDashboardConfig) {
+  form {
+    method = FormMethod.post
+    action = "${config.pathPrefix}/login"
+    div {
+      classes = setOf("mb-4")
+      textArea {
+        name = "token"
+        rows = "4"
+        classes = setOf(
+          "w-full", "rounded-md", "border", "border-gray-300", "px-3", "py-2",
+          "text-sm", "font-mono", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
+          "placeholder-gray-400",
+        )
+        placeholder = "eyJhbGciOiJSUzI1NiIs..."
+      }
+    }
+    button {
+      type = ButtonType.submit
+      classes = setOf(
+        "w-full", "rounded-md", "bg-indigo-600", "px-4", "py-2",
+        "text-sm", "font-medium", "text-white",
+        "hover:bg-indigo-700", "focus:outline-none", "focus:ring-2", "focus:ring-indigo-500",
+      )
+      +"Sign in"
     }
   }
 }

--- a/kairo-rest/src/main/kotlin/kairo/rest/auth/AuthReceiver.kt
+++ b/kairo-rest/src/main/kotlin/kairo/rest/auth/AuthReceiver.kt
@@ -12,6 +12,7 @@ import io.ktor.server.auth.BearerTokenCredential
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
 import io.ktor.server.routing.RoutingCall
+import io.ktor.util.AttributeKey
 import java.net.URI
 import java.security.interfaces.RSAPublicKey
 import kairo.rest.RestEndpoint
@@ -54,6 +55,12 @@ public class AuthReceiver<E : RestEndpoint<*, *>> internal constructor(
   }
 
   public companion object {
+    /**
+     * Attribute key for overriding the bearer token on a call.
+     * Used by the admin dashboard to supply a JWT from a cookie.
+     */
+    public val BearerTokenOverride: AttributeKey<String> = AttributeKey("BearerTokenOverride")
+
     private val sentinel: RestEndpoint<Unit, Unit> = object : RestEndpoint<Unit, Unit>() {}
 
     /**
@@ -74,7 +81,9 @@ public fun AuthReceiver<*>.public(): Unit =
   Unit
 
 public fun AuthReceiver<*>.verify(config: VerifierConfig): JWTPrincipal {
-  val credential = call.principal<BearerTokenCredential>() ?: throw NoJwt()
+  val credential = call.principal<BearerTokenCredential>()
+    ?: call.attributes.getOrNull(BearerTokenOverride)?.let { BearerTokenCredential(it) }
+    ?: throw NoJwt()
   val verifier = createVerifier(config, credential)
   val payload = try {
     verifier.verify(credential.token)


### PR DESCRIPTION
## Summary
- Adds `kairo-admin` module: a full-featured admin dashboard for Kairo servers
- Adds `kairo-kdocs` module: serves Dokka-generated API docs at `/_kdocs`
- Adds OAuth 2.0 Authorization Code flow for admin dashboard login
- Adds cookie-based browser auth via `AuthReceiver.BearerTokenOverride`

## OAuth login flow

1. User visits `/_admin/` → no cookie → auth fails → redirect to `/_admin/login`
2. `/_admin/login` → generates CSRF state cookie → redirects to OAuth provider (e.g. Auth0)
3. User authenticates → provider redirects to `/_admin/callback?code=...&state=...`
4. Server validates state, exchanges code for JWT access token, sets `kairo_admin_token` HttpOnly cookie
5. Redirect to `/_admin/` → cookie present → `verify()` succeeds via `BearerTokenOverride`

## Key changes

### `kairo-admin` (new module)
- **`AdminDashboardFeature`** — Kairo feature with HTML dashboard, OAuth routes, and data collectors
- **`AdminOAuthConfig`** — Generic OAuth 2.0 config (`authorizeUrl`, `tokenUrl`, `clientId`, `clientSecret`, `scopes`, `audience`, `providerName`, `logoutUrl`)
- **`AdminDashboardHandler`** — Routes: `GET /login` (start OAuth), `GET /callback` (exchange code), `POST /logout` (clear cookie), plus `authGet`/`authPost` wrappers that redirect to login on auth failure
- **`LoginView`** — Error page shown only when OAuth is not configured; when configured, `/login` redirects directly to provider

### `kairo-kdocs` (new module)
- **`KdocsFeature`** — Serves Dokka HTML docs from the classpath at `/_kdocs`

### `kairo-rest` (modified)
- **`AuthReceiver.kt`** — Added `BearerTokenOverride` attribute key so admin dashboard can supply JWT from cookie instead of `Authorization` header; added `forCall()` factory for non-endpoint auth checks

## Consumer code
```kotlin
AdminDashboardFeature(
  config = AdminDashboardConfig(
    serverName = "AI",
    oauth = AdminOAuthConfig(
      authorizeUrl = "https://auth.example.com/authorize",
      tokenUrl = "https://auth.example.com/oauth/token",
      clientId = "...",
      clientSecret = "...",
      providerName = "Auth0",
    ),
  ),
  auth = { superuser() },
),
KdocsFeature(),
```

## Test plan
- [ ] Verify `/_admin/` without cookie redirects to `/_admin/login`
- [ ] Verify `/_admin/login` redirects to OAuth provider with correct params
- [ ] Verify callback exchanges code for token and sets session cookie
- [ ] Verify `/_admin/` with valid cookie loads the dashboard
- [ ] Verify `/_admin/logout` clears cookie
- [ ] Verify CSRF state validation rejects tampered state
- [ ] Verify `Authorization: Bearer` header still works for API access
- [ ] Verify `/_kdocs` serves Dokka docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)