### PR TITLE
Bump Exposed BOM from 1.0.0 to 1.1.0

### DIFF
--- a/bom-full/build.gradle.kts
+++ b/bom-full/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
   // exposed
   // https://github.com/JetBrains/Exposed/releases
-  api(platform("org.jetbrains.exposed:exposed-bom:1.0.0"))
+  api(platform("org.jetbrains.exposed:exposed-bom:1.1.0"))
 
   // gcp
   // https://github.com/googleapis/java-cloud-bom/releases


### PR DESCRIPTION
## Summary
- Bumps `exposed-bom` from 1.0.0 to 1.1.0 in `bom-full/build.gradle.kts`
- Maintenance release with no breaking API changes

## Key fixes in Exposed 1.1.0
- Connection leak when coroutine is cancelled during `suspendTransaction` (EXPOSED-982)
- `Select For Update` returning cached entity instead of updated entity
- MySQL SSL connection error

## Test plan
- [x] CI passes
- [x] Bump Kairo BOM in beijing and verify Exposed resolves to 1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)