### PR TITLE
Bump Ktor BOM from 3.3.3 to 3.4.1

### DIFF
--- a/bom-full/build.gradle.kts
+++ b/bom-full/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 
   // ktor
   // https://github.com/ktorio/ktor/releases
-  api(platform("io.ktor:ktor-bom:3.3.3"))
+  api(platform("io.ktor:ktor-bom:3.4.1"))
 
   // log4j
   // https://github.com/apache/logging-log4j2/releases


### PR DESCRIPTION
## Summary
- Bumps Ktor BOM from 3.3.3 to 3.4.1
- [Release notes](https://github.com/ktorio/ktor/releases/tag/3.4.1)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)